### PR TITLE
Added fix for generating mappings + other fixes/additions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["source-map"]
 categories = ["web-programming"]
 repository = "https://github.com/kaleidawave/source-map"
 
+[lints.clippy]
+all = "deny"
+
 [dependencies]
 lsp-types = { version = "0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/examples/source_map_creation.rs
+++ b/examples/source_map_creation.rs
@@ -7,8 +7,9 @@ fn main() {
     };
     use std::{env::args, fs};
 
-    /// A simple string split, returns chunk plus byte indexes of chunk
-    fn n_words_a_line(fs: &mut impl FileSystem, string: &str, output: &mut impl ToString) {
+    // Splits a string by whitespace and appends them back ensuring there
+    // are a fixed number of words on each line
+    fn transform(string: &str, output: &mut impl ToString, fs: &mut impl FileSystem) {
         let source_id = SourceId::new(fs, "file.txt".into(), string.to_owned());
 
         for (idx, chunk) in string
@@ -45,7 +46,7 @@ fn main() {
 
     let mut fs = GlobalStore;
 
-    n_words_a_line(&mut fs, &file_as_string, &mut source_map);
+    transform(&file_as_string, &mut source_map, &mut fs);
 
     fs::write(output, source_map.build_with_inline_source_map(&fs)).expect("Write failed");
 }

--- a/examples/source_map_creation.rs
+++ b/examples/source_map_creation.rs
@@ -5,78 +5,31 @@ fn main() {
         global_store::GlobalStore, FileSystem, SourceId, SpanWithSource, StringWithSourceMap,
         ToString,
     };
-    use split_indices::split_indices_from_str;
-    use std::{convert::TryInto, env::args, fs};
+    use std::{env::args, fs};
 
     /// A simple string split, returns chunk plus byte indexes of chunk
-    mod split_indices {
-        use std::{ops::Range, str::CharIndices};
-
-        pub struct SplitIndices<'a, T: Fn(char) -> bool> {
-            pub string: &'a str,
-            pub function: T,
-            pub last_match: usize,
-            pub char_iterator: CharIndices<'a>,
-            pub exhausted: bool,
-        }
-
-        pub fn split_indices_from_str<'a, T: Fn(char) -> bool>(
-            string: &'a str,
-            function: T,
-        ) -> SplitIndices<'a, T> {
-            SplitIndices {
-                string,
-                function,
-                last_match: 0,
-                char_iterator: string.char_indices(),
-                exhausted: false,
-            }
-        }
-
-        impl<'a, T: Fn(char) -> bool> Iterator for SplitIndices<'a, T> {
-            type Item = (Range<usize>, &'a str);
-
-            fn next(&mut self) -> Option<Self::Item> {
-                if self.exhausted {
-                    return None;
-                }
-                let Self {
-                    char_iterator,
-                    function,
-                    ..
-                } = self;
-
-                let find_map = char_iterator
-                    .by_ref()
-                    .find_map(|(idx, char)| (function)(char).then(|| (idx, char)));
-
-                if let Some((idx, char)) = find_map {
-                    let start = self.last_match;
-                    let end = idx + char.len_utf8();
-                    self.last_match = end;
-                    let range = start..idx;
-                    Some((range.clone(), &self.string[range]))
-                } else {
-                    let range = self.last_match..self.string.len();
-                    self.exhausted = true;
-                    Some((range.clone(), &self.string[range]))
-                }
-            }
-        }
-    }
-
-    fn remove_whitespace(fs: &mut impl FileSystem, string: &str, output: &mut impl ToString) {
+    fn n_words_a_line(fs: &mut impl FileSystem, string: &str, output: &mut impl ToString) {
         let source_id = SourceId::new(fs, "file.txt".into(), string.to_owned());
 
-        for (range, chunk) in split_indices_from_str(string, char::is_whitespace) {
-            if !chunk.is_empty() {
-                let base_span = SpanWithSource {
-                    start: range.start.try_into().unwrap(),
-                    end: range.end.try_into().unwrap(),
-                    source: source_id,
-                };
-                output.add_mapping(&base_span);
-                output.push_str(chunk);
+        for (idx, chunk) in string
+            .split(char::is_whitespace)
+            .filter(|s| !s.is_empty())
+            .enumerate()
+        {
+            // Compute the start position in the string using pointer offsets
+            let start = chunk.as_ptr() as u32 - string.as_ptr() as u32;
+            let base_span = SpanWithSource {
+                start,
+                end: start + chunk.len() as u32,
+                source: source_id,
+            };
+            output.add_mapping(&base_span);
+            output.push_str(chunk);
+            output.push(' ');
+
+            const WORDS_PER_LINE: usize = 5;
+            if idx % WORDS_PER_LINE + 1 == WORDS_PER_LINE {
+                output.push_new_line();
             }
         }
     }
@@ -92,7 +45,7 @@ fn main() {
 
     let mut fs = GlobalStore;
 
-    remove_whitespace(&mut fs, &file_as_string, &mut source_map);
+    n_words_a_line(&mut fs, &file_as_string, &mut source_map);
 
     fs::write(output, source_map.build_with_inline_source_map(&fs)).expect("Write failed");
 }

--- a/src/lines_columns_indexes.rs
+++ b/src/lines_columns_indexes.rs
@@ -31,8 +31,8 @@ impl LineStarts {
 
     pub fn byte_indexes_crosses_lines(&self, pos1: usize, pos2: usize) -> usize {
         debug_assert!(pos1 <= pos2);
-        let first_line_backwards = self.get_index_of_line_pos_is_on(pos1);
-        let second_line_backwards = self.get_index_of_line_pos_is_on(pos2);
+        let first_line_backwards = self.get_line_pos_is_on(pos1);
+        let second_line_backwards = self.get_line_pos_is_on(pos2);
         second_line_backwards - first_line_backwards
     }
 
@@ -40,15 +40,22 @@ impl LineStarts {
         self.byte_indexes_crosses_lines(pos1, pos2) > 0
     }
 
-    pub(crate) fn get_index_of_line_pos_is_on(&self, pos: usize) -> usize {
+    /// 0 indexed
+    pub(crate) fn get_line_pos_is_on(&self, pos: usize) -> usize {
+        self.get_line_and_column_pos_is_on(pos).0
+    }
+
+    /// 0 indexed
+    pub(crate) fn get_line_and_column_pos_is_on(&self, pos: usize) -> (usize, usize) {
         let backwards_index = self
             .0
             .iter()
             .rev()
             .position(|index| pos >= *index)
-            .expect("pos1 out of bounds");
+            .expect("pos out of bounds");
 
-        (self.0.len() - 1) - backwards_index
+        let line = (self.0.len() - 1) - backwards_index;
+        (line, pos - self.0[line])
     }
 }
 

--- a/src/source_id.rs
+++ b/src/source_id.rs
@@ -17,13 +17,6 @@ impl SourceId {
     pub fn new(filesystem: &mut impl FileSystem, path: PathBuf, content: String) -> Self {
         filesystem.new_source_id(path, content)
     }
-
-    /// For content which does not have a source file **use with caution**
-    pub const NULL: Self = Self(0);
-
-    pub const fn is_null(&self) -> bool {
-        self.0 == 0
-    }
 }
 
 #[cfg(feature = "self-rust-tokenize")]

--- a/tests/to_tokens.rs
+++ b/tests/to_tokens.rs
@@ -2,7 +2,7 @@
 #[test]
 fn to_tokens() {
     use self_rust_tokenize::SelfRustTokenize;
-    use source_map::{SourceId, SpanWithSource};
+    use source_map::{Nullable, SourceId, SpanWithSource};
 
     let span = SpanWithSource {
         start: 10,


### PR DESCRIPTION
- use `LineSplits` for making mappings (removes old implementation)
- add new umbrella `ToString` implementer struct
- adds `Nullable` to simplify null position markers

TODO
- [x] test in ezno
- [ ] add test?