### PR TITLE
Use &str for codespan Files content

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,7 @@ jobs:
         run: cargo clippy
 
   publish-ability:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ codespan-reporting = { version = "0.11", optional = true }
 self-rust-tokenize = { version = "0.3", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen = "=0.2.89"
+wasm-bindgen = "0.2"
 tsify = "0.4.5"
 
 [features]

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -236,7 +236,7 @@ where
         &'a self,
         id: Self::FileId,
     ) -> Result<Self::Source, codespan_reporting::files::Error> {
-        Ok(&self.0.sources[id.0 as usize].content)
+        Ok(&self.0.sources[id.0 as usize - 1].content)
     }
 
     // Implementation copied from codespan codebase

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -207,7 +207,9 @@ impl MapFileStore<WithPathMap> {
             self.new_source_id(path.to_path_buf(), content);
         }
     }
+}
 
+impl<T: PathMap> MapFileStore<T> {
     #[cfg(feature = "codespan-reporting")]
     pub fn into_code_span_store(&self) -> CodeSpanStore {
         CodeSpanStore(self)
@@ -215,10 +217,13 @@ impl MapFileStore<WithPathMap> {
 }
 
 #[cfg(feature = "codespan-reporting")]
-pub struct CodeSpanStore<'a>(&'a MapFileStore<WithPathMap>);
+pub struct CodeSpanStore<'a, T>(&'a MapFileStore<T>);
 
 #[cfg(feature = "codespan-reporting")]
-impl<'a> codespan_reporting::files::Files<'a> for CodeSpanStore<'a> {
+impl<'a, T> codespan_reporting::files::Files<'a> for CodeSpanStore<'a, T>
+where
+    T: PathMap,
+{
     type FileId = SourceId;
     type Name = String;
     type Source = &'a str;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -211,7 +211,7 @@ impl MapFileStore<WithPathMap> {
 
 impl<T: PathMap> MapFileStore<T> {
     #[cfg(feature = "codespan-reporting")]
-    pub fn into_code_span_store(&self) -> CodeSpanStore {
+    pub fn into_code_span_store(&self) -> CodeSpanStore<T> {
         CodeSpanStore(self)
     }
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -146,7 +146,7 @@ impl<M: PathMap> FileSystem for MapFileStore<M> {
 pub struct NoPathMap;
 
 #[derive(Default)]
-pub struct WithPathMap(HashMap<PathBuf, SourceId>);
+pub struct WithPathMap(pub(crate) HashMap<PathBuf, SourceId>);
 
 impl PathMap for NoPathMap {
     fn set_path(&mut self, _path: PathBuf, _source: SourceId) {}
@@ -206,6 +206,10 @@ impl MapFileStore<WithPathMap> {
         } else {
             self.new_source_id(path.to_path_buf(), content);
         }
+    }
+
+    pub fn get_paths(&self) -> &HashMap<PathBuf, SourceId> {
+        &self.mappings.0
     }
 }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -111,11 +111,6 @@ pub trait FileSystem: Sized {
     {
         self.get_source_by_id(source_id, |s| s.content.get(indexer).map(|v| v.to_owned()))
     }
-
-    #[cfg(feature = "codespan-reporting")]
-    fn into_code_span_store(&self) -> CodeSpanStore<Self> {
-        CodeSpanStore(self)
-    }
 }
 
 impl<M: PathMap> FileSystem for MapFileStore<M> {
@@ -212,17 +207,21 @@ impl MapFileStore<WithPathMap> {
             self.new_source_id(path.to_path_buf(), content);
         }
     }
+
+    #[cfg(feature = "codespan-reporting")]
+    pub fn into_code_span_store(&self) -> CodeSpanStore {
+        CodeSpanStore(self)
+    }
 }
 
 #[cfg(feature = "codespan-reporting")]
-pub struct CodeSpanStore<'a, T: FileSystem>(&'a T);
+pub struct CodeSpanStore<'a>(&'a MapFileStore<WithPathMap>);
 
 #[cfg(feature = "codespan-reporting")]
-impl<'a, T: FileSystem> codespan_reporting::files::Files<'a> for CodeSpanStore<'a, T> {
+impl<'a> codespan_reporting::files::Files<'a> for CodeSpanStore<'a> {
     type FileId = SourceId;
     type Name = String;
-    // TODO should just be &str
-    type Source = String;
+    type Source = &'a str;
 
     fn name(&'a self, id: Self::FileId) -> Result<Self::Name, codespan_reporting::files::Error> {
         Ok(self.0.get_file_path(id).display().to_string())
@@ -232,7 +231,7 @@ impl<'a, T: FileSystem> codespan_reporting::files::Files<'a> for CodeSpanStore<'
         &'a self,
         id: Self::FileId,
     ) -> Result<Self::Source, codespan_reporting::files::Error> {
-        Ok(self.0.get_file_content(id))
+        Ok(&self.0.sources[id.0 as usize].content)
     }
 
     // Implementation copied from codespan codebase

--- a/src/span.rs
+++ b/src/span.rs
@@ -268,7 +268,7 @@ pub struct LineColumnPosition<T: StringEncoding> {
     pub line: u32,
     pub column: u32,
     pub source: SourceId,
-    encoding: T,
+    pub encoding: T,
 }
 
 impl<T: StringEncoding> LineColumnPosition<T> {
@@ -290,7 +290,7 @@ pub struct LineColumnSpan<T: StringEncoding> {
     pub line_end: u32,
     pub column_end: u32,
     pub source: SourceId,
-    encoding: T,
+    pub encoding: T,
 }
 
 impl<T: StringEncoding> LineColumnSpan<T> {
@@ -364,6 +364,7 @@ impl From<lsp_types::Range> for LineColumnSpan<Utf8> {
             line_end: lsp_range.end.line,
             column_end: lsp_range.end.character,
             encoding: Utf8,
+            // TODO not great
             source: SourceId::NULL,
         }
     }

--- a/src/to_string.rs
+++ b/src/to_string.rs
@@ -28,6 +28,10 @@ pub trait ToString {
     }
 
     fn characters_on_current_line(&self) -> u32;
+
+    fn is_counting(&self) -> bool {
+        false
+    }
 }
 
 // TODO clarify calls
@@ -203,6 +207,10 @@ impl ToString for StringWithOptionalSourceMap {
     fn characters_on_current_line(&self) -> u32 {
         self.since_new_line
     }
+
+    fn is_counting(&self) -> bool {
+        self.quit_after.is_some()
+    }
 }
 
 /// Counts text until a limit. Used for telling whether the text is greater than some threshold
@@ -247,6 +255,9 @@ impl ToString for Counter {
     fn characters_on_current_line(&self) -> u32 {
         // TODO?
         0
+    }
+    fn is_counting(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
- Reduces cloning
- However rules out GlobalStore
- (also use looser version for wasm-bindgen)
